### PR TITLE
Updated covidTracker & made responsive

### DIFF
--- a/covidTracker.html
+++ b/covidTracker.html
@@ -49,6 +49,21 @@
       text-decoration: none;
       color: white;
     }
+/* NEW: media queries  */
+
+@media (max-width:560px){
+      .return a{
+        font-size: 12px;
+        padding:  .4em;
+      }
+
+      .mb-3{
+        margin-right: 60px;
+      }
+      .live{
+        font-size: 1rem;
+      }
+    }
   </style>
 </head>
 


### PR DESCRIPTION
## Updated covidTracker ✅

 In mobile device the "Go Back" button was overlapping the Covid Tracker heading i.e "COVID 19 LIVE UPDATES". So Made more responsive and fixed the code.

- I have hosted your site on [Covid-Tracker-Demo](https://covid-demo.surge.sh/)
- You can check the doc for [Surge](https://surge.sh/)  which is a free hosting site. 

### Here's the issue. 
#### This is what it was looking like in mobile view :
 
 ![img](https://ik.imagekit.io/tfme5aczhhf/images-for-github/tr:w-300/Screenshot_20210715_221746_ldhcXddLm.jpg)

#### After fixing the code. - result
    
![updatedimg](https://ik.imagekit.io/tfme5aczhhf/images-for-github/tr:w-300/Screenshot_20210715_221733_FwjZ9UM5T.jpg)